### PR TITLE
implement start-end dates slicing

### DIFF
--- a/parameters/paper_plots/figure2/m_log.json
+++ b/parameters/paper_plots/figure2/m_log.json
@@ -3,7 +3,7 @@
         "name" : "bitcoin_paper_fig2_m",
         "path": "datasets/btc_h.csv",
         "column_price": "close",
-        "column_time": "start",
+        "time_column": "start",
         "length" : 25000,
         "eval_proportion": 0.16,
         "test_proportion": 0.2

--- a/parameters/paper_plots/figure2/s_POWC_log.json
+++ b/parameters/paper_plots/figure2/s_POWC_log.json
@@ -3,7 +3,7 @@
         "name" : "bitcoin_paper_fig2_s",
         "path": "datasets/btc_h.csv",
         "column_price": "close",
-        "column_time": "start",
+        "time_column": "start",
         "length" : 25000,
         "eval_proportion": 0.16,
         "test_proportion": 0.2

--- a/parameters/paper_plots/figure3/m_log.json
+++ b/parameters/paper_plots/figure3/m_log.json
@@ -3,7 +3,7 @@
         "name" : "bitcoin_paper_fig3_m",
         "path": "datasets/btc_h.csv",
         "column_price": "close",
-        "column_time": "start",
+        "time_column": "start",
         "length" : 25000,
         "eval_proportion": 0.16,
         "test_proportion": 0.2

--- a/parameters/paper_plots/figure3/s_POWC_log.json
+++ b/parameters/paper_plots/figure3/s_POWC_log.json
@@ -3,7 +3,7 @@
         "name" : "bitcoin_paper_fig3_s",
         "path": "datasets/btc_h.csv",
         "column_price": "close",
-        "column_time": "start",
+        "time_column": "start",
         "length" : 25000,
         "eval_proportion": 0.16,
         "test_proportion": 0.2

--- a/parameters/paper_plots/figure6/m_log.json
+++ b/parameters/paper_plots/figure6/m_log.json
@@ -3,7 +3,7 @@
         "name": "bitcoin_paper_fig6_m",
         "path": "datasets/btc_h.csv",
         "column_price": "close",
-        "column_time": "start",
+        "time_column": "start",
         "length": 25000,
         "eval_proportion": 0.16,
         "test_proportion": 0.2

--- a/parameters/paper_plots/figure6/m_log_random_discount.json
+++ b/parameters/paper_plots/figure6/m_log_random_discount.json
@@ -3,7 +3,7 @@
         "name" : "bitcoin_paper_fig6_m_random_discount",
         "path": "datasets/btc_h.csv",
         "column_price": "close",
-        "column_time": "start",
+        "time_column": "start",
         "length" : 25000,
         "eval_proportion": 0.16,
         "test_proportion": 0.2

--- a/parameters/paper_plots/figure7/m_log.json
+++ b/parameters/paper_plots/figure7/m_log.json
@@ -3,7 +3,7 @@
         "name" : "bitcoin_paper_fig7_m",
         "path": "datasets/btc_h.csv",
         "column_price": "close",
-        "column_time": "start",
+        "time_column": "start",
         "length" : 25000,
         "eval_proportion": 0.16,
         "test_proportion": 0.2

--- a/parameters/paper_plots/figure7/m_log_random_discount.json
+++ b/parameters/paper_plots/figure7/m_log_random_discount.json
@@ -3,7 +3,7 @@
         "name" : "bitcoin_paper_fig7_m_random_discount",
         "path": "datasets/btc_h.csv",
         "column_price": "close",
-        "column_time": "start",
+        "time_column": "start",
         "length" : 25000,
         "eval_proportion": 0.16,
         "test_proportion": 0.2

--- a/parameters/paper_plots/figures8_10_and_11/m_log.json
+++ b/parameters/paper_plots/figures8_10_and_11/m_log.json
@@ -3,7 +3,7 @@
         "name" : "bitcoin_paper_fig8-10-11_m",
         "path": "datasets/btc_h.csv",
         "column_price": "close",
-        "column_time": "start",
+        "time_column": "start",
         "length" : 25000,
         "eval_proportion": 0.16,
         "test_proportion": 0.2

--- a/parameters/paper_plots/figures8_10_and_11/s_ALR_log.json
+++ b/parameters/paper_plots/figures8_10_and_11/s_ALR_log.json
@@ -3,7 +3,7 @@
         "name" : "bitcoin_paper_fig8-10-11_sALR",
         "path": "datasets/btc_h.csv",
         "column_price": "close",
-        "column_time": "start",
+        "time_column": "start",
         "length" : 25000,
         "eval_proportion": 0.16,
         "test_proportion": 0.2

--- a/parameters/paper_plots/figures8_10_and_11/s_SR_log.json
+++ b/parameters/paper_plots/figures8_10_and_11/s_SR_log.json
@@ -3,7 +3,7 @@
         "name" : "bitcoin_paper_fig8-10-11_sSR",
         "path": "datasets/btc_h.csv",
         "column_price": "close",
-        "column_time": "start",
+        "time_column": "start",
         "length" : 25000,
         "eval_proportion": 0.16,
         "test_proportion": 0.2

--- a/parameters/paper_plots/figures9_and_12/m_log.json
+++ b/parameters/paper_plots/figures9_and_12/m_log.json
@@ -3,7 +3,7 @@
         "name": "bitcoin_paper_fig9-12_m",
         "path": "datasets/btc_h.csv",
         "column_price": "close",
-        "column_time": "start",
+        "time_column": "start",
         "length": 25000,
         "eval_proportion": 0.16,
         "test_proportion": 0.2

--- a/parameters/paper_plots/figures9_and_12/s_SR_log.json
+++ b/parameters/paper_plots/figures9_and_12/s_SR_log.json
@@ -3,7 +3,7 @@
         "name": "bitcoin_paper_fig9-12_s",
         "path": "datasets/btc_h.csv",
         "column_price": "close",
-        "column_time": "start",
+        "time_column": "start",
         "length": 25000,
         "eval_proportion": 0.16,
         "test_proportion": 0.2

--- a/src/data/datasets.py
+++ b/src/data/datasets.py
@@ -18,10 +18,17 @@ def fetch_dataset():
 def load_dataset():
     df = pd.read_csv(f"{const.REFERENCE_DIRECTORY}/{par.dataset.path}")
     df = df.rename({par.dataset.column_price: 'price'}, axis='columns')
-    if len(df) < par.dataset.end:
-        raise ValueError('par.dataset.end exceeds dataset length')
-    return df.iloc[par.dataset.start:par.dataset.end]
+    return slice_df(df)
 
+
+def slice_df(df: pd.DataFrame):
+    if isinstance(par.dataset.start, str) and isinstance(par.dataset.end, str):
+        return df.set_index(par.dataset.time_column or 'start').loc[par.dataset.start:par.dataset.end]
+    if isinstance(par.dataset.start, int) and isinstance(par.dataset.end, int):
+        if len(df) < par.dataset.end:
+            raise ValueError('par.dataset.end exceeds dataset length')
+        return df.iloc[par.dataset.start:par.dataset.end]
+        
 
 def split_df(df: pd.DataFrame, cut: float):
     split_point = int(len(df) * cut)

--- a/src/parameters.py
+++ b/src/parameters.py
@@ -163,9 +163,10 @@ class DatasetParameters():
         self,
         name: str = "unkown_dataset",
         column_price: str = "close",
-        column_time: str = "start",
+        time_column: str = "start",
         path: str | None = None,
-        start_end=[0, None],
+        start: int | str = 0,
+        end: int | str = None,
         length: int | None = None,
         var: float = 0.,
         eval_proportion: float = 0.2,
@@ -173,15 +174,19 @@ class DatasetParameters():
     ):
         self.name = name
         self.column_price = column_price
-        self.column_time = column_time
+        self.time_column = time_column
         self.path = path or "default_path"
 
-        self.start, self.end = start_end
+        self.start = start
+        self.end = end
         self.length = length
-        if length is None:
+        
+        if length and self.end:
+            raise ValueError('You should not specify a length if start and end are given')
+        if length is None and isinstance(start, int) and isinstance(end, int):
             self.length = self.end - self.start
-        elif self.end is None:
-            self.end = self.length
+        if self.end is None:
+            self.end = self.start + self.length
 
         self.var = var
         self.eval_proportion = eval_proportion

--- a/src/parameters.py
+++ b/src/parameters.py
@@ -166,7 +166,7 @@ class DatasetParameters():
         time_column: str = "start",
         path: str | None = None,
         start: int | str = 0,
-        end: int | str = None,
+        end: int | str | None = None,
         length: int | None = None,
         var: float = 0.,
         eval_proportion: float = 0.2,


### PR DESCRIPTION
Implements the possibility to input dates as strings for start-end entries of json configuration of a dataset.
Example:
```
    "dataset": {
        "name" : "start end dates test",
        "path": "datasets/btc_h.csv",
        "column_price": "close",
        "column_time": "start",
        "start" : "2018-09-11",
        "end" : "2020-02",
        "eval_proportion": 0.16,
        "test_proportion": 0.2
    }
```